### PR TITLE
move emails config parameter to global config

### DIFF
--- a/pipeline/config.groovy.template
+++ b/pipeline/config.groovy.template
@@ -19,6 +19,9 @@ BASE="<EDIT THIS>"
 // Set a good location for storing large temp files here (probably not /tmp)
 TMPDIR="/tmp"
 
+# Enter email here to get notified by email about failures
+EMAILS=""
+
 // If you are using the default reference data, download it now in 
 // the hg19 folder (see hg19/README)
 //

--- a/pipeline/scripts/run_tests.sh
+++ b/pipeline/scripts/run_tests.sh
@@ -24,9 +24,6 @@
 #
 ########################################################
 
-# Enter email here to get notified by email about failures
-EMAILS=""
-
 TESTS='*_test'
 
 if [ ! -z "$1" ];


### PR DESCRIPTION
Moved EMAILS config item from run_tests.sh to config.groovy.template, so future updates won't overwrite it.
