### PR TITLE
Use ANNOVAR_DB instead of ANNOVAR/../humandb since the variable exist…

### DIFF
--- a/pipeline/scripts/install.sh
+++ b/pipeline/scripts/install.sh
@@ -223,7 +223,7 @@ MISSING_ANNOVAR=""
 ANNOVAR_DB_FILES="hg19_snp138.txt hg19_esp6500siv2_all.txt hg19_refGene.txt hg19_ALL.sites.2014_10.txt hg19_phastConsElements46way.txt hg19_ljb26_all.txt"
 for i in $ANNOVAR_DB_FILES ;  
 do
-    [ -e $ANNOVAR/../humandb/$i ] || {
+    [ -e $ANNOVAR_DB/$i ] || {
         MISSING_ANNOVAR="$i $MISSING_ANNOVAR"
     }
 done

--- a/pipeline/scripts/reformat_bed_files.groovy
+++ b/pipeline/scripts/reformat_bed_files.groovy
@@ -61,7 +61,7 @@ annotate = {
     exec """
         echo "Annotating genes ..."
 
-        JAVA_OPTS="-Xmx1g" $GROOVY -cp $GROOVY_NGS/groovy-ngs-utils.jar $BASE/pipeline/scripts/annotate_genes.groovy -r $ANNOVAR/../humandb/hg19_refGene.txt $input.bed > $output.bed
+        JAVA_OPTS="-Xmx1g" $GROOVY -cp $GROOVY_NGS/groovy-ngs-utils.jar $BASE/pipeline/scripts/annotate_genes.groovy -r $ANNOVAR_DB/hg19_refGene.txt $input.bed > $output.bed
     """
 }
 


### PR DESCRIPTION
…s 

By default ANNOVAR_DB == ANNOVAR/../humandb but since they are configurable, both the install script and the reformat_bed_files.groovy get confused if that's not the case.
