### PR TITLE
FastQC check fails because summary.txt files are not found

### DIFF
--- a/pipeline/pipeline_stages_config.groovy
+++ b/pipeline/pipeline_stages_config.groovy
@@ -296,7 +296,7 @@ check_fastqc = {
        // appears to contain natural biases that flag QC failures 
        // here.
        exec """
-           cat fastqc/${sample}_*fastqc/summary.txt |
+           cat fastqc/"${sample}"_*fastqc/summary.txt |
                grep -v "Per base sequence content" |
                grep -v "Per base GC content" |
                grep -q 'FAIL' && exit 1

--- a/pipeline/pipeline_stages_config.groovy
+++ b/pipeline/pipeline_stages_config.groovy
@@ -296,7 +296,7 @@ check_fastqc = {
        // appears to contain natural biases that flag QC failures 
        // here.
        exec """
-           cat "fastqc/${sample}_*fastqc/summary.txt" |
+           cat fastqc/${sample}_*fastqc/summary.txt |
                grep -v "Per base sequence content" |
                grep -v "Per base GC content" |
                grep -q 'FAIL' && exit 1


### PR DESCRIPTION
The fastqc output is checked by grepping for "fastqc/${sample}_*fastqc/summary.txt", but bash won't expand asterisks in quotes. If the purpose is to quote the sample name so that it captures spaces, then the sample variable can be quoted by itself.
