### PR TITLE
The awk check for the Illumina version on fastqc fails on non-gawk awks

### DIFF
--- a/pipeline/pipeline_stages_config.groovy
+++ b/pipeline/pipeline_stages_config.groovy
@@ -317,7 +317,7 @@ check_fastqc = {
 
     check("FASTQ Format") {
         exec """
-            awk -F'\\t' '/Illumina/ { match(\$2, /[0-9.]+/ , result); exit(result[0]<1.7) }' fastqc/${sample}_*_fastqc/fastqc_data.txt
+            awk -F'\\t' '/Illumina/ { where=match(\$2, /[0-9.]+/); { result=substr(\$2, where, RLENGTH); exit(result<1.7); } }' fastqc/${sample}_*_fastqc/fastqc_data.txt
         ""","local"
     } otherwise {
         println "=" * 100


### PR DESCRIPTION
The three-parameter variant of the match function is a gawk extension. The patch converts the check to use standard awk

Another option would be to explicitly call it with gawk.

This was picked up because the default version of awk in Ubuntu is mawk, not gawk  (at least on 15.04)
