### PR TITLE
create and rm unique tmp dir for each MarkDuplicates task

### DIFF
--- a/pipeline/pipeline_stages_config.groovy
+++ b/pipeline/pipeline_stages_config.groovy
@@ -526,8 +526,11 @@ dedup = {
 
     var MAX_DUPLICATION_RATE : 30
 
+    def safe_tmp_dir = [TMPDIR, UUID.randomUUID().toString()].join( File.separator )
     exec """
-        $JAVA -Xmx4g -Djava.io.tmpdir=$TMPDIR -jar $PICARD_HOME/lib/MarkDuplicates.jar
+        mkdir -p "$safe_tmp_dir"
+
+        $JAVA -Xmx4g -Djava.io.tmpdir=$safe_tmp_dir -jar $PICARD_HOME/lib/MarkDuplicates.jar
              INPUT=$input.bam 
              REMOVE_DUPLICATES=true 
              VALIDATION_STRINGENCY=LENIENT 
@@ -535,6 +538,8 @@ dedup = {
              METRICS_FILE=$output.metrics
              CREATE_INDEX=true
              OUTPUT=$output.bam
+
+        rm -r "$safe_tmp_dir"
     """
 
     check {


### PR DESCRIPTION
workaround mark duplicates bug that leaves world writable tmp directories behind
