### PR TITLE
Fix qc runid

### DIFF
--- a/pipeline/pipeline_stages_config.groovy
+++ b/pipeline/pipeline_stages_config.groovy
@@ -1085,6 +1085,7 @@ qc_excel_report = {
                     -w $LOW_COVERAGE_WIDTH
                     -low qc ${inputs.dedup.metrics.withFlag('-metrics')}
                     -o $output.xlsx
+                    -p $run_id
                     $inputs.sample_cumulative_coverage_proportions  
                     $inputs.sample_interval_statistics 
                     $inputs.gz


### PR DESCRIPTION
include run ID in generated QC PDF filename
