### PR TITLE
synonymous snvs in splicing regions are given higher priority (CPIPE-27)

### DIFF
--- a/pipeline/config.groovy.template
+++ b/pipeline/config.groovy.template
@@ -182,7 +182,7 @@ JAVA="java"
 // Note: snpeff is not needed by default pipeline
 SNPEFF="$TOOLS/snpeff/3.1"
 
-// Genome needed (currently) only if using expanded splice regions
+// Genome needed for expanded splice regions
 HG19_CHROM_INFO="$REFBASE/hg19.genome"
 
 // Trimmomatic location
@@ -204,3 +204,7 @@ INTERVAL_PADDING_SNV=10
 
 // interval padding for indels in filter_variants
 INTERVAL_PADDING_INDEL=25
+
+// do not filter synonymous with this range
+ALLOW_SYNONYMOUS_INTRON=25
+ALLOW_SYNONYMOUS_EXON=2

--- a/pipeline/pipeline.groovy
+++ b/pipeline/pipeline.groovy
@@ -75,6 +75,7 @@ run {
     // Create a single BED that contains all the regions we want to call
     // variants in
     create_combined_target + 
+    create_synonymous_target + // regions where synonymous snvs are not filtered
 
     generate_pipeline_id + // make a new pipeline run ID file if required
 

--- a/pipeline/scripts/check_metadata.py
+++ b/pipeline/scripts/check_metadata.py
@@ -42,7 +42,7 @@ def is_valid_enumeration( field, allowed ):
   return len(field) == 0 or field in allowed
 
 def is_valid_date( field ):
-  return len(field) == 0 or len(field) == 8 and field.is_digit()
+  return len(field) == 0 or len(field) == 8 and field.isdigit()
 
 def validate( fh, out, err ):
   headers = fh.readline().strip().split('\t')

--- a/pipeline/scripts/examine_variant.py
+++ b/pipeline/scripts/examine_variant.py
@@ -59,6 +59,8 @@ def examine( gene, batch, sample, out ):
   report_gene( 'Annovar', gene, './batches/{0}/analysis/variants/*{1}.merge.dedup.realign.recal.filter*.vep.sort.hg19_multianno.csv'.format( batch, sample ), sys.stdout, separator=',', display=set( ['Chr', 'Start', 'Ref', 'Alt', 'Func', 'Priority_Index'] ), use_header=True )
   report_gene( 'Significance', gene, './batches/{0}/analysis/variants/*{1}.merge.dedup.realign.recal.filter*.vep.sort.hg19_multianno.con.sig.csv'.format( batch, sample ), sys.stdout, separator=',', display=set( ['Chr', 'Start', 'Ref', 'Alt', 'Func', 'Priority_Index'] ), use_header=True )
   report_gene( 'Final', gene, './batches/{0}/analysis/results/*{1}.annovarx.csv'.format( batch, sample ), sys.stdout, separator=',', display=set( ['Chr', 'Start', 'Ref', 'Alt', 'Priority_Index', '#Obs'] ), use_header=True )
+  # alternative results
+  report_gene( 'Final', gene, './batches/{0}/results/*{1}.annovarx.csv'.format( batch, sample ), sys.stdout, separator=',', display=set( ['Chr', 'Start', 'Ref', 'Alt', 'Priority_Index', '#Obs'] ), use_header=True )
 
 if __name__ == '__main__':
   parser = argparse.ArgumentParser(description='Examine variant filtering')


### PR DESCRIPTION
Regions around splicing regions can now be specified such that synonymous SNVs are not automatically filtered.

Note that this change requires extra settings in config.groovy:
ALLOW_SYNONYMOUS_INTRON=25
ALLOW_SYNONYMOUS_EXON=2
