### PR TITLE
minor fixes for integration tests

### DIFF
--- a/pipeline/pipeline_stage_initialize.groovy
+++ b/pipeline/pipeline_stage_initialize.groovy
@@ -419,7 +419,7 @@ finish_batch_run = segment {
 
 // configure target regions and other settings for each profile
 initialize_profiles = segment {
-    set_target_info + 
-    create_splice_site_bed
+    set_target_info // + 
+    // create_splice_site_bed // currently disabled, not used (and requires annovar)
 }
 

--- a/pipeline/scripts/install.sh
+++ b/pipeline/scripts/install.sh
@@ -395,7 +395,7 @@ while read line; do
     fi
   fi
 done <"$MANIFEST"
-popd $REFBASE
+popd 
 
 msg "Success: all the dependencies I know how to check are OK"
 


### PR DESCRIPTION
have disabled the create splice site stage because it relies on Annovar and is not currently used.
