### PR TITLE
fix bedtools 2.25 parameters, compress coverage files, various minor fixes

### DIFF
--- a/pipeline/config.groovy.template
+++ b/pipeline/config.groovy.template
@@ -115,7 +115,13 @@ ANNOVAR_DB="$TOOLS/annovar/humandb"
 // (or point this to your installation)
 // GATK="$TOOLS/gatk/2.3.9"
 GATK="$TOOLS/gatk/2.8-1-g932cd3a"
+
+// gatk < 2.8
 GATK_LEGACY=false
+
+// do not do genotyping, directly call the variants
+// gatk < 3.5
+GATK_VARIANT_ONLY=false
 
 // Utilities for making Excel files 
 EXCEL="$TOOLS/excel/1.0"

--- a/pipeline/pipeline_stage_germline.groovy
+++ b/pipeline/pipeline_stage_germline.groovy
@@ -19,17 +19,21 @@
 /////////////////////////////////////////////////////////////////////////////////
 load 'pipeline_helpers.groovy'
 
+/////////////////////////////////////////////////////////////////////////////////
 germline_analysis_phase_1 = segment {
     // all samples do this
     variant_discovery // stage_variant_calling, result is sample.combined.g.vcf
 }
 
+/////////////////////////////////////////////////////////////////////////////////
 // given the g.vcf of the individual, convert this to a genotype.raw.vcf
 // we do this for probands and individuals, but not samples that are just for trios
 germline_genotype_gvcfs = {
     stage_status('germline_genotype_gvcfs', 'enter', sample);
     // joint_call_individual
     // java -Xmx24g -jar /usr/local/gatk/3.5/GenomeAnalysisTK.jar -T GenotypeGVCFs -R /vlsci/VR0320/shared/production/1.0.4/hg19/ucsc.hg19.fasta --disable_auto_index_creation_and_locking_when_reading_rods --num_threads 1 --variant 00NA12877.hap.raw.g.vcf --variant 00NA12878.hap.raw.g.vcf --variant 00NA12879.hap.raw.g.vcf --out txxxx.genotype.raw.vcf -ped txxxx.ped -log txxxx.GenotypeGVCFs.log --dbsnp /vlsci/VR0320/shared/production/1.0.4/hg19/dbsnp_138.hg19.vcf -G Standard -A AlleleBalance -A AlleleBalanceBySample -A DepthPerAlleleBySample -A GCContent -A GenotypeSummaries -A HardyWeinberg -A LikelihoodRankSumTest -A MappingQualityZero -A SampleList -A SpanningDeletions -A StrandBiasBySample -A TandemRepeatAnnotator -A VariantType -A TransmissionDisequilibriumTest
+    // 23-may-2016
+    // java -Xmx24g -jar /usr/local/gatk/3.5/GenomeAnalysisTK.jar -T GenotypeGVCFs -R /vlsci/VR0320/shared/production/1.0.4/hg19/ucsc.hg19.fasta --disable_auto_index_creation_and_locking_when_reading_rods --num_threads 1 --variant 00NA12877.hap.raw.g.vcf --variant 00NA12878.hap.raw.g.vcf --variant 00NA12879.hap.raw.g.vcf --out txxxx.genotype.raw.fewerA.vcf -ped txxxx.ped -log txxxx.GenotypeGVCFs.fewerA.log --dbsnp /vlsci/VR0320/shared/production/1.0.4/hg19/dbsnp_138.hg19.vcf -A AlleleBalance -A VariantType
     output.dir="variants"
 
     var call_conf:5.0, 
@@ -46,21 +50,8 @@ germline_genotype_gvcfs = {
                     --out $output
                     --logging_level INFO
                     --dbsnp $DBSNP
-                    -G Standard
                     -A AlleleBalance
-                    -A AlleleBalanceBySample
-                    -A DepthPerAlleleBySample
-                    -A GCContent
-                    -A GenotypeSummaries
-                    -A HardyWeinberg
-                    -A LikelihoodRankSumTest
-                    -A MappingQualityZero
-                    -A SampleList
-                    -A SpanningDeletions
-                    -A StrandBiasBySample
-                    -A TandemRepeatAnnotator
                     -A VariantType
-                    -A TransmissionDisequilibriumTest
                     -stand_call_conf $call_conf 
                     -stand_emit_conf $emit_conf
             """, "gatk_genotype"
@@ -69,6 +60,24 @@ germline_genotype_gvcfs = {
     stage_status('germline_genotype_gvcfs', 'exit', sample);
 }
 
+/////////////////////////////////////////////////////////////////////////////////
+// this is the variant only pathway
+// we already have the vcf, just forward it on to the next stage
+germline_genotype_vcfs = {
+    stage_status('germline_genotype_vcfs', 'enter', sample);
+    output.dir="variants"
+    produce("${sample}.individual.genotype.raw.vcf") {
+        from("variants/${sample}.hc.vcf") {
+           exec """
+               cp "$input" "$output"
+           """
+        }
+    }
+
+    stage_status('germline_genotype_vcfs', 'exit', sample);
+}
+
+/////////////////////////////////////////////////////////////////////////////////
 genotype_refinement_individual = {
     doc "skips the refinement steps and passes on the vcf to the next stage unchanged"
     output.dir="variants"
@@ -81,8 +90,17 @@ genotype_refinement_individual = {
     }
 }
 
-germline_analysis_phase_2 = segment {
-    germline_genotype_gvcfs +
-    filter_variants +
-    merge_variants
+if (GATK_VARIANT_ONLY) {
+    germline_analysis_phase_2 = segment {
+        germline_genotype_vcfs +
+        filter_variants +
+        merge_variants
+    }
+}
+else {
+    germline_analysis_phase_2 = segment {
+        germline_genotype_gvcfs +
+        filter_variants +
+        merge_variants
+    }
 }

--- a/pipeline/pipeline_stage_trio.groovy
+++ b/pipeline/pipeline_stage_trio.groovy
@@ -42,6 +42,7 @@ trio_genotype_gvcfs = {
     var call_conf:5.0, 
         emit_conf:5.0
 
+    // java -Xmx24g -jar /usr/local/gatk/3.5/GenomeAnalysisTK.jar -T GenotypeGVCFs -R /vlsci/VR0320/shared/production/1.0.4/hg19/ucsc.hg19.fasta --disable_auto_index_creation_and_locking_when_reading_rods --num_threads 1 --variant 00NA12877.hap.raw.g.vcf --variant 00NA12878.hap.raw.g.vcf --variant 00NA12879.hap.raw.g.vcf --out txxxx.genotype.raw.fewerA.vcf -ped txxxx.ped -log txxxx.GenotypeGVCFs.fewerA.log --dbsnp /vlsci/VR0320/shared/production/1.0.4/hg19/dbsnp_138.hg19.vcf -A AlleleBalance -A VariantType
     produce ("${sample}.trio.genotype.raw.vcf") {
         from(from_list) {
             stage_status("trio_analysis_phase_2", "inputs: ${inputs}", sample)
@@ -57,19 +58,7 @@ trio_genotype_gvcfs = {
                     --dbsnp $DBSNP
                     -G Standard
                     -A AlleleBalance
-                    -A AlleleBalanceBySample
-                    -A DepthPerAlleleBySample
-                    -A GCContent
-                    -A GenotypeSummaries
-                    -A HardyWeinberg
-                    -A LikelihoodRankSumTest
-                    -A MappingQualityZero
-                    -A SampleList
-                    -A SpanningDeletions
-                    -A StrandBiasBySample
-                    -A TandemRepeatAnnotator
                     -A VariantType
-                    -A TransmissionDisequilibriumTest
                     -stand_call_conf $call_conf 
                     -stand_emit_conf $emit_conf
             """, "gatk_genotype"

--- a/pipeline/pipeline_stage_variant_analysis.groovy
+++ b/pipeline/pipeline_stage_variant_analysis.groovy
@@ -43,9 +43,10 @@ vcf_filter_child = {
     doc "remove any hom ref variants"
     stage_status("vcf_filter_child", "enter", "${sample} ${branch.analysis}");
     output.dir="variants"
+    // 23-may-2016 java -jar /usr/local/gatk/3.5/GenomeAnalysisTK.jar -T SelectVariants -R /vlsci/VR0320/shared/production/1.0.4/hg19/ucsc.hg19.fasta --variant txxxx.genotype.raw.split.norm.vcf -select 'vc.getGenotype("00NA12879").isHomVar() || vc.getGenotype("00NA12879").isHet() ' -o txxxx.genotype.raw.split.norm.ChildOnly.vcf
     transform ("norm.vcf") to("soi.vcf") {
         exec """
-            $JAVA -Xmx3g -jar $GATK/GenomeAnalysisTK.jar -T SelectVariants -R $REF --variant $input.norm.vcf -select '!vc.getGenotype("$sample").isHomRef()' -o $output.soi.vcf
+            $JAVA -Xmx3g -jar $GATK/GenomeAnalysisTK.jar -T SelectVariants -R $REF --variant $input.norm.vcf -select 'vc.getGenotype("$sample").isHomVar() || vc.getGenotype("$sample").isHet()' -o $output.soi.vcf
         """
     }
     stage_status("vcf_filter_child", "exit", "${sample} ${branch.analysis}");

--- a/pipeline/pipeline_stage_variant_calling.groovy
+++ b/pipeline/pipeline_stage_variant_calling.groovy
@@ -58,6 +58,8 @@ call_variants_hc = {
     // Default values of confidence thresholds
     // come from the Broad web site. However
     // these may be higher than suitable in our context
+   
+    // old implementation
     var call_conf:5.0, 
         emit_conf:5.0
 
@@ -78,6 +80,47 @@ call_variants_hc = {
     }
 }
 
+//////////////////////////////////////////////////////////////////
+call_variants_individual_vcf = {
+    doc "Call variants and output to VCF"
+    stage_status("call_variants_individual_vcf", "enter", sample); 
+    output.dir="variants"
+
+    // haplotype calling when not part of a trio
+    // java -Xmx24g -jar /usr/local/gatk/3.5/GenomeAnalysisTK.jar -T HaplotypeCaller -R /vlsci/VR0320/shared/production/1.0.4/hg19/ucsc.hg19.fasta --emitRefConfidence GVCF --num_cpu_threads_per_data_thread 1 -A AlleleBalance -A GCContent -A GenotypeSummaries -A LikelihoodRankSumTest -A StrandBiasBySample -A VariantType -I $sample\.merge.dedup.realign.recal.bam -L /vlsci/VR0320/shared/production/1.0.4/designs/nextera_rapid_capture_exome_1.2/target_regions.bed -o $sample\.hap.raw.g.vcf --bamOutput $sample\.HC.bam -log $sample\.log -ped txxxx.ped --dbsnp /vlsci/VR0320/shared/production/1.0.4/hg19/dbsnp_138.hg19.vcf
+
+    var call_conf:5.0, 
+        emit_conf:5.0
+
+    // transform("bam") to ("hc.vcf", "hc.bam") {
+    produce("${sample}.hc.vcf", "${sample}.hc.bam") {
+        from("bam") {
+            exec """
+                java -Xmx24g -jar $GATK/GenomeAnalysisTK.jar -T HaplotypeCaller 
+                    -R $REF 
+                    --num_cpu_threads_per_data_thread 1 
+                    -A AlleleBalance 
+                    -A GCContent 
+                    -A GenotypeSummaries 
+                    -A LikelihoodRankSumTest 
+                    -A StrandBiasBySample 
+                    -A VariantType 
+                    -I $input.bam
+                    -L $COMBINED_TARGET 
+                    -o $output.hc.vcf 
+                    --bamOutput $output.hc.bam 
+                    --logging_level INFO
+                    --dbsnp $DBSNP 
+                    --interval_padding $INTERVAL_PADDING_CALL
+                    -stand_call_conf $call_conf 
+                    -stand_emit_conf $emit_conf
+            """, "gatk_call_variants"
+        }
+    }
+    stage_status("call_variants_individual_vcf", "exit", sample); 
+}
+
+//////////////////////////////////////////////////////////////////
 call_variants_individual_gvcf = {
     doc "Call variants and output to GVCF"
     stage_status("call_variants_individual_gvcf", "enter", sample); 
@@ -85,6 +128,8 @@ call_variants_individual_gvcf = {
 
     // haplotype calling when not part of a trio
     //java -Xmx24g -jar /usr/local/gatk/3.5/GenomeAnalysisTK.jar -T HaplotypeCaller -R /vlsci/VR0320/shared/production/1.0.4/hg19/ucsc.hg19.fasta --emitRefConfidence GVCF --num_cpu_threads_per_data_thread 1 -G Standard -A AlleleBalance -A AlleleBalanceBySample -A DepthPerAlleleBySample -A GCContent -A GenotypeSummaries -A HardyWeinberg -A HomopolymerRun -A LikelihoodRankSumTest -A LowMQ -A MappingQualityZero -A SampleList -A SpanningDeletions -A StrandBiasBySample -A TandemRepeatAnnotator -A VariantType -A TransmissionDisequilibriumTest -I $sample\.merge.dedup.realign.recal.bam -L /vlsci/VR0320/shared/production/1.0.4/designs/nextera_rapid_capture_exome_1.2/target_regions.bed -o $sample\.hap.raw.g.vcf --bamOutput $sample\.HC.bam -log $sample\.log -ped txxxx.ped --dbsnp /vlsci/VR0320/shared/production/1.0.4/hg19/dbsnp_138.hg19.vcf
+    // 23-may-2016
+    // java -Xmx24g -jar /usr/local/gatk/3.5/GenomeAnalysisTK.jar -T HaplotypeCaller -R /vlsci/VR0320/shared/production/1.0.4/hg19/ucsc.hg19.fasta --emitRefConfidence GVCF --num_cpu_threads_per_data_thread 1 -A AlleleBalance -A GCContent -A GenotypeSummaries -A LikelihoodRankSumTest -A StrandBiasBySample -A VariantType -I $sample\.merge.dedup.realign.recal.bam -L /vlsci/VR0320/shared/production/1.0.4/designs/nextera_rapid_capture_exome_1.2/target_regions.bed -o $sample\.hap.raw.g.vcf --bamOutput $sample\.HC.bam -log $sample\.log -ped txxxx.ped --dbsnp /vlsci/VR0320/shared/production/1.0.4/hg19/dbsnp_138.hg19.vcf
 
     // transform("bam") to ("hc.g.vcf", "hc.bam") {
     produce("${sample}.hc.g.vcf", "${sample}.hc.bam") {
@@ -94,23 +139,12 @@ call_variants_individual_gvcf = {
                     -R $REF 
                     --emitRefConfidence GVCF 
                     --num_cpu_threads_per_data_thread 1 
-                    -G Standard 
                     -A AlleleBalance 
-                    -A AlleleBalanceBySample 
-                    -A DepthPerAlleleBySample 
                     -A GCContent 
                     -A GenotypeSummaries 
-                    -A HardyWeinberg 
-                    -A HomopolymerRun 
                     -A LikelihoodRankSumTest 
-                    -A LowMQ 
-                    -A MappingQualityZero 
-                    -A SampleList 
-                    -A SpanningDeletions 
                     -A StrandBiasBySample 
-                    -A TandemRepeatAnnotator 
                     -A VariantType 
-                    -A TransmissionDisequilibriumTest 
                     -I $input.bam
                     -L $COMBINED_TARGET 
                     -o $output.hc.g.vcf 
@@ -124,6 +158,7 @@ call_variants_individual_gvcf = {
     stage_status("call_variants_individual_gvcf", "exit", sample); 
 }
 
+//////////////////////////////////////////////////////////////////
 call_variants_trio_gvcf = {
     doc "Call variants with a PED file and output to GVCF"
     output.dir="variants"
@@ -132,30 +167,20 @@ call_variants_trio_gvcf = {
     // TODO is this separation required?
 
     // java -Xmx24g -jar /usr/local/gatk/3.5/GenomeAnalysisTK.jar -T HaplotypeCaller -R /vlsci/VR0320/shared/production/1.0.4/hg19/ucsc.hg19.fasta --emitRefConfidence GVCF --num_cpu_threads_per_data_thread 1 -G Standard -A AlleleBalance -A AlleleBalanceBySample -A DepthPerAlleleBySample -A GCContent -A GenotypeSummaries -A HardyWeinberg -A HomopolymerRun -A LikelihoodRankSumTest -A LowMQ -A MappingQualityZero -A SampleList -A SpanningDeletions -A StrandBiasBySample -A TandemRepeatAnnotator -A VariantType -A TransmissionDisequilibriumTest -I $sample\.merge.dedup.realign.recal.bam -L /vlsci/VR0320/shared/production/1.0.4/designs/nextera_rapid_capture_exome_1.2/target_regions.bed -o $sample\.hap.raw.gvcf --bamOutput $sample\.HC.bam -log $sample\.log -ped txxxx.ped --dbsnp /vlsci/VR0320/shared/production/1.0.4/hg19/dbsnp_138.hg19.vcf
-
+    // 23-may-2016
+    // java -Xmx24g -jar /usr/local/gatk/3.5/GenomeAnalysisTK.jar -T HaplotypeCaller -R /vlsci/VR0320/shared/production/1.0.4/hg19/ucsc.hg19.fasta --emitRefConfidence GVCF --num_cpu_threads_per_data_thread 1 -A AlleleBalance -A GCContent -A GenotypeSummaries -A LikelihoodRankSumTest -A StrandBiasBySample -A VariantType -I $sample\.merge.dedup.realign.recal.bam -L /vlsci/VR0320/shared/production/1.0.4/designs/nextera_rapid_capture_exome_1.2/target_regions.bed -o $sample\.hap.raw.g.vcf --bamOutput $sample\.HC.bam -log $sample\.log -ped txxxx.ped --dbsnp /vlsci/VR0320/shared/production/1.0.4/hg19/dbsnp_138.hg19.vcf
     transform("bam", "ped") to ("hc.g.vcf", "hc.bam") {
         exec """
             java -Xmx24g -jar $GATK/GenomeAnalysisTK.jar -T HaplotypeCaller 
                 -R $REF 
                 --emitRefConfidence GVCF 
                 --num_cpu_threads_per_data_thread 1 
-                -G Standard 
                 -A AlleleBalance 
-                -A AlleleBalanceBySample 
-                -A DepthPerAlleleBySample 
                 -A GCContent 
                 -A GenotypeSummaries 
-                -A HardyWeinberg 
-                -A HomopolymerRun 
                 -A LikelihoodRankSumTest 
-                -A LowMQ 
-                -A MappingQualityZero 
-                -A SampleList 
-                -A SpanningDeletions 
                 -A StrandBiasBySample 
-                -A TandemRepeatAnnotator 
                 -A VariantType 
-                -A TransmissionDisequilibriumTest 
                 -I $input.bam
                 -L $COMBINED_TARGET 
                 -o $output.hc.g.vcf 
@@ -208,6 +233,7 @@ call_pgx = {
     stage_status("call_pgx", "exit", sample)
 }
 
+//////////////////////////////////////////////////////////////////////
 merge_pgx = {
     doc "Merge multiple VCF files into one file"
     output.dir="variants"
@@ -216,13 +242,29 @@ merge_pgx = {
 
     if(!file("../design/${target_name}.pgx.vcf").exists()) {
         stage_status("merge_pgx", "forwarding", target_name)
-        forward input.hc.g.vcf.toString() // workaround for Bpipe bug
+        if (GATK_VARIANT_ONLY) {
+            forward input.hc.vcf.toString() // workaround for Bpipe bug
+        }
+        else {
+            forward input.hc.g.vcf.toString() // workaround for Bpipe bug
+        }
         stage_status("merge_pgx", "exit (returning)", target_name)
         return
     }
 
     msg "Merging vcf files: " + inputs.vcf
-    exec """
+    if (GATK_VARIANT_ONLY) {
+        exec """
+            $JAVA -Xmx3g -jar $GATK/GenomeAnalysisTK.jar
+            -T CombineVariants
+            -R $REF
+            --variant $input.hc.vcf
+            --variant $input.pgx.vcf
+            --out $output.vcf
+         """
+    }
+    else {
+        exec """
             $JAVA -Xmx3g -jar $GATK/GenomeAnalysisTK.jar
             -T CombineVariants
             -R $REF
@@ -230,6 +272,7 @@ merge_pgx = {
             --variant $input.pgx.vcf
             --out $output.vcf
          """
+    }
 
     stage_status("merge_pgx", "exit", target_name)
 }
@@ -238,11 +281,17 @@ merge_pgx = {
 // segments
 //////////////////////////////////////////////////////////////////////
 
-variant_discovery = segment {
-    call_variants_individual_gvcf + 
-    call_pgx + 
-    merge_pgx
-    // filter_variants + // moved to after genotyping
-    // merge_variants_gvcf
+if (GATK_VARIANT_ONLY) {
+    variant_discovery = segment {
+        call_variants_individual_vcf + 
+        call_pgx + 
+        merge_pgx
+    }
 }
-
+else {
+    variant_discovery = segment {
+        call_variants_individual_gvcf + 
+        call_pgx + 
+        merge_pgx
+    }
+}

--- a/pipeline/scripts/gap_annotator.py
+++ b/pipeline/scripts/gap_annotator.py
@@ -30,6 +30,7 @@
 
 import collections
 import datetime
+import gzip
 import math
 import os
 import sys
@@ -405,7 +406,13 @@ def main():
     else:
         download_db(sys.stderr)
         data_source = init_db(open('gap.db', 'r'), sys.stderr)
-    find_gaps(open(args.coverage, 'r'), args.min_gap_width, args.min_coverage_ok, sys.stdout, data_source, sys.stderr)
+
+    if args.coverage.endswith('.gz'):
+        coverage_fh = gzip.open(args.coverage, 'r')
+    else:
+        coverage_fh = open(args.coverage, 'r')
+
+    find_gaps(coverage_fh, args.min_gap_width, args.min_coverage_ok, sys.stdout, data_source, sys.stderr)
 
 if __name__ == '__main__':
     main()

--- a/pipeline/scripts/install.sh
+++ b/pipeline/scripts/install.sh
@@ -244,13 +244,15 @@ else
 fi
 
 # download dbnsfp dataset
-if [ ! -e "$TOOLS/vep_plugins/dbNSFP/dbNSFPv3.0b2a.zip" ]; then
+#if [ ! -e "$TOOLS/vep_plugins/dbNSFP/dbNSFPv3.0b2a.zip" ]; then
+if [ ! -e "$TOOLS/vep_plugins/dbNSFP/dbNSFPv2.9.1.zip" ]; then
   pushd "$TOOLS/vep_plugins/dbNSFP"
-  DBNSFP_URL="ftp://dbnsfp:dbnsfp@dbnsfp.softgenetics.com/dbNSFPv3.0b2a.zip"
+  #DBNSFP_URL="ftp://dbnsfp:dbnsfp@dbnsfp.softgenetics.com/dbNSFPv3.0b2a.zip"
+  DBNSFP_URL="ftp://dbnsfp:dbnsfp@dbnsfp.softgenetics.com/dbNSFPv2.9.1.zip"
   msg "downloading dbnsfp..."
   wget $DBNSFP_URL || err "Failed to download $DBNSFP_URL"
   msg "processing dbnsfp..."
-  unzip dbNSFPv3.0b2a.zip
+  unzip dbNSFPv2.9.1.zip
   cat dbNSFP*chr* | "$HTSLIB/bgzip" -c > dbNSFP.gz
   "$HTSLIB/tabix" -s 1 -b 2 -e 2 dbNSFP.gz
   msg "processing dbnsfp: done"

--- a/pipeline/scripts/qc_report.py
+++ b/pipeline/scripts/qc_report.py
@@ -45,6 +45,7 @@
 
 import collections
 import datetime
+import gzip
 import re
 import sys
 
@@ -472,8 +473,19 @@ def main():
     parser.add_argument('--padding', required=False, help='comma separated padding stats for all,indel,snv')
     args = parser.parse_args()
     write_log(sys.stderr, 'opening {0} for karyotype'.format(args.exome_cov))
-    karyotype = calculate_karyotype(open(args.exome_cov, 'r'), log=sys.stderr)
-    summary = calculate_summary(open(args.report_cov, 'r'), args.threshold, log=sys.stderr)
+
+    if args.exome_cov.endswith('.gz'):
+        exome_cov_fh = gzip.open(args.exome_cov, 'r')
+    else:
+        exome_cov_fh = open(args.exome_cov, 'r')
+    karyotype = calculate_karyotype(exome_cov_fh, log=sys.stderr)
+
+    if args.report_cov.endswith('.gz'):
+        report_cov_fh = gzip.open(args.report_cov, 'r')
+    else:
+        report_cov_fh = open(args.report_cov, 'r')
+    summary = calculate_summary(report_cov_fh, args.threshold, log=sys.stderr)
+
     sample = parse_metadata(open(args.meta, 'r'), args.study)
     if args.write_karyotype:
         write_karyotype(open(args.write_karyotype, 'w'), karyotype, sample)

--- a/pipeline/scripts/vcf_annotate.sh
+++ b/pipeline/scripts/vcf_annotate.sh
@@ -8,6 +8,37 @@
 # * 6: condel
 # * 7: dbnsfp
 
+# 23-may-2016 perl /vlsci/VR0320/shared/production/2.2.0/tools/vep/83/variant_effect_predictor.pl 
+# --allele_number 
+# --cache 
+# --canonical 
+# --check_existing 
+# --check_alleles  
+# --dir /vlsci/VR0320/shared/production/2.2.0/tools/vep/vep_cache 
+# --dir_plugins /vlsci/VR0320/shared/production/2.2.0/tools/vep_plugins 
+# --fasta /vlsci/VR0320/shared/production/2.2.0/tools/vep/vep_cache/homo_sapiens/83_GRCh37/Homo_sapiens.GRCh37.75.dna.primary_assembly.fa 
+# --force_overwrite 
+# --gmaf 
+# --hgvs 
+# -i $trio\.genotype.raw.split.norm.ChildOnly.vcf 
+# --maf_1kg 
+# --maf_esp 
+# --maf_exac 
+# -o $trio\.genotype.raw.split.norm.ChildOnly.vep.83.vcf 
+# --offline 
+# --per_gene 
+# --plugin Condel,/vlsci/VR0320/shared/production/2.2.0/tools/vep_plugins/condel/2.4/config,s 
+# --plugin dbNSFP,/vlsci/VR0320/shared/production/2.2.0/tools/vep_plugins/dbNSFP_2.9.1/dbNSFP.EDIT.gz,LRT_score,LRT_pred,phyloP100way_vertebrate,GERP++_RS,CADD_raw,CADD_phred,MutationTaster_score,MutationTaster_pred,1000Gp1_AC,1000Gp1_AF,ExAC_AC,ExAC_AF,clinvar_rs,clinvar_clnsig,clinvar_trait,Polyphen2_HDIV_score,Polyphen2_HDIV_pred
+# --polyphen b 
+# --protein 
+# --pubmed 
+# --refseq 
+# --sift b 
+# -species homo_sapiens 
+# --symbol 
+# --vcf 
+# --vcf_info_field ANN 
+
 VARIANTS=`grep -c -v '^#' < $1`
 echo "$VARIANTS variant(s) found in $1"
 if [ $VARIANTS -eq 0 ];
@@ -35,7 +66,7 @@ else
         --offline \
         --per_gene \
         --plugin Condel,$6/config,s \
-        --plugin dbNSFP,$7/dbNSFP.gz,LRT_score,LRT_pred,phyloP7way_vertebrate,GERP++_RS,CADD_raw,CADD_phred,MutationTaster_score,MutationTaster_pred,1000Gp3_AC,1000Gp3_AF,ExAC_AC,ExAC_AF,clinvar_rs,clinvar_clnsig,clinvar_trait,Polyphen2_HDIV_score,Polyphen2_HDIV_pred \
+        --plugin dbNSFP,$7/dbNSFP.gz,LRT_score,LRT_pred,phyloP100way_vertebrate,GERP++_RS,CADD_raw,CADD_phred,MutationTaster_score,MutationTaster_pred,1000Gp1_AC,1000Gp1_AF,ExAC_AC,ExAC_AF,clinvar_rs,clinvar_clnsig,clinvar_trait,Polyphen2_HDIV_score,Polyphen2_HDIV_pred \
         --polyphen b \
         --protein \
         --pubmed \

--- a/pipeline/tests/check_metadata_test.py
+++ b/pipeline/tests/check_metadata_test.py
@@ -1,0 +1,22 @@
+
+import unittest
+import imp
+import os
+import random
+import re
+import sys
+import StringIO
+
+sys.path.append('../scripts/')
+import check_metadata
+
+class CheckMetadataTest(unittest.TestCase):
+
+  def test_validate_empty(self):
+    src = StringIO.StringIO('')
+    out = StringIO.StringIO()
+    err = StringIO.StringIO()
+    check_metadata.validate(src, out, err)
+    lines = err.getvalue().split('\n')
+    assert lines[0] == "ERROR: file only contains one line. Are you using Windows style line feeds?"
+

--- a/tools/vep_plugins/dbNSFP/2016-01-13/dbNSFP.pm
+++ b/tools/vep_plugins/dbNSFP/2016-01-13/dbNSFP.pm
@@ -301,7 +301,7 @@ sub run {
   
   # get required data
   my %return =
-    map {$_ => $data->{$_}}
+    map {$_ => ($data->{$_} =~ s/[|]/&/gr) } # PATCH: replace | with & to prevent conflict with existing field sep
     map {$data->{$_} =~ s/\;/\,/g; $_ }
     grep {$data->{$_} ne '.'}              # ignore missing data
     grep {defined($self->{cols}->{$_})}  # only include selected cols


### PR DESCRIPTION
Main change is to fix the bedtools command line calls to be compatible with the latest bedtools release (>2.24).

GATK < 3.5 is also now supported by setting GATK_VARIANT_ONLY to true.
