### PR TITLE
include proband in hard filter call

### DIFF
--- a/pipeline/pipeline_stage_variant_analysis.groovy
+++ b/pipeline/pipeline_stage_variant_analysis.groovy
@@ -26,7 +26,7 @@ filter_table = {
     stage_status("table_filter", "enter", "${sample} ${branch.analysis}");
     output.dir="results"
     exec """
-        python $SCRIPTS/filter_tsv.py --ad ${HARD_FILTER_AD} --af ${HARD_FILTER_AF} --dp ${HARD_FILTER_DP} --qual ${HARD_FILTER_QUAL} < $input > $output
+        python $SCRIPTS/filter_tsv.py --ad ${HARD_FILTER_AD} --af ${HARD_FILTER_AF} --dp ${HARD_FILTER_DP} --qual ${HARD_FILTER_QUAL} --proband ${sample} < $input > $output
     """
     stage_status("table_filter", "exit", "${sample} ${branch.analysis}");
 }

--- a/pipeline/scripts/filter_tsv.py
+++ b/pipeline/scripts/filter_tsv.py
@@ -63,7 +63,6 @@ def allow_variant(headers, fields, af_min, qual_min, dp_min, ad_min, stats, prob
     # p is proband; c is count; default DPp to low in case proband is not specified
     sample_results = {'DP': 0, 'DPc': 0, 'DPp': 0}
     passing_samples = set()
-    ad_ok = False
     # look at dp
     for header, field in zip(headers, fields):
         if header.endswith('.DP') and field.isdigit():
@@ -78,6 +77,7 @@ def allow_variant(headers, fields, af_min, qual_min, dp_min, ad_min, stats, prob
                 passing_samples.add(header[:-3])
 
     # look at ad
+    ad_ok = False
     for header, field in zip(headers, fields):
         if header.endswith('.AD') and header[:-3] in passing_samples:
             allele_depth = field.split(',')[1]


### PR DESCRIPTION
in the new hard filtering rules the proband is treated differently: if it has DP above the threshold, the variant is allowed even if the overall sum does not reach the threshold.

this change adds the proband as an argument to the filter_tsv script.
