### PR TITLE
Support for custom perl libs in tools/perl5

### DIFF
--- a/pipeline/config.groovy.template
+++ b/pipeline/config.groovy.template
@@ -191,6 +191,9 @@ EXCLUDE_VARIANT_TYPES="synonymous SNV"
 // Use default Java installed in PATH
 JAVA="java"
 
+// Support custom perl libraries installed in tools/perl5
+PERL5LIB="\$PERL5LIB:$BASE/tools/perl5"
+
 // SNPEFF location
 // Note: snpeff is not needed by default pipeline
 SNPEFF="$TOOLS/snpeff/3.1"

--- a/pipeline/pipeline_stage_variant_analysis.groovy
+++ b/pipeline/pipeline_stage_variant_analysis.groovy
@@ -79,7 +79,7 @@ vcf_post_annotation_filter = {
     // PERL5LIB="/vlsci/VR0320/shared/production/2.2.0/tools/vep/83" perl /vlsci/VR0320/shared/production/2.2.0/tools/vep/83/filter_vep.pl --input_file txxxx.genotype.raw.split.norm.ChildOnly.vep.83.vcf --format vcf --filter "Consequence not matches stream" --only_matched --filter "BIOTYPE match protein_coding" --filter "Feature" -o txxxx.genotype.raw.split.norm.ChildOnly.vep.83.FILTER.vcf
     // first copy input to output, otherwise filter_vep creates an empty file
     exec """
-        /usr/bin/env bash $SCRIPTS/vcf_post_annotation_filter.sh "$input.vcf" "$output.vcf" "$VEP"
+        /usr/bin/env bash $SCRIPTS/vcf_post_annotation_filter.sh "$input.vcf" "$output.vcf" "$VEP" "$TOOLS"
     """
     stage_status("vcf_post_annotation_filter", "exit", "${sample} ${branch.analysis}");
 }

--- a/pipeline/scripts/install.sh
+++ b/pipeline/scripts/install.sh
@@ -209,6 +209,7 @@ else
     if [ "$REPLY" == "y" ];
     then
         cd $VEP
+        export PERL5LIB="$PERL5LIB:$TOOLS/perl5:$TOOLS/perl5/lib/perl5"
         # convert ../vep_cache to absolute path
         VEP_CACHE=`echo "$VEP" | sed 's/\/[^\/]*$/\/vep_cache/'`
         msg "INFO: VEP is installing homo_sapiens_vep"

--- a/pipeline/scripts/vcf_annotate.sh
+++ b/pipeline/scripts/vcf_annotate.sh
@@ -39,7 +39,11 @@
 # --vcf 
 # --vcf_info_field ANN 
 
+TOOLS="$5"
 VARIANTS=`grep -c -v '^#' < $1`
+
+export PERL5LIB="$PERL5LIB:$TOOLS/perl5:$TOOLS/perl5/lib/perl5"
+
 echo "$VARIANTS variant(s) found in $1"
 if [ $VARIANTS -eq 0 ];
 then
@@ -54,7 +58,7 @@ else
         --check_alleles \
         --check_existing \
         --dir $4/../vep_cache \
-        --dir_plugins $5/vep_plugins \
+        --dir_plugins $TOOLS/vep_plugins \
         --fasta $4/../vep_cache/homo_sapiens/83_GRCh37/Homo_sapiens.GRCh37.75.dna.primary_assembly.fa.gz \
         --force_overwrite \
         --gmaf \

--- a/pipeline/scripts/vcf_post_annotation_filter.sh
+++ b/pipeline/scripts/vcf_post_annotation_filter.sh
@@ -3,6 +3,9 @@
 # 1: input
 # 2: output
 # 3: vep
+# 4: tools dir
+
+TOOLS="$4"
 
 VARIANTS=`grep -c -v '^#' < $1`
 echo "$VARIANTS variant(s) found in $1"
@@ -10,7 +13,7 @@ if [ $VARIANTS -eq 0 ];
 then
   cp $1 $2
 else
-  PERL5LIB="$3" perl $3/filter_vep.pl \
+  PERL5LIB="$TOOLS/perl5:$TOOLS/perl5/lib/perl5:$3" perl $3/filter_vep.pl
     --input_file $1 \
     --filter "Consequence not matches stream" \
     --filter "BIOTYPE match protein_coding" \


### PR DESCRIPTION
we aren't allowed to install perl libraries on our cluster in the default
location so we need to install them in an alternative location
and add that to the path used by Perl. This change adds support for
a PERL5LIB setting in config.groovy that adds tools/perl5 to the 
perl libs path everywhere that Perl is used.
