### PR TITLE
make install set config to use GATK 3.5 if present in tools

### DIFF
--- a/pipeline/scripts/install.sh
+++ b/pipeline/scripts/install.sh
@@ -104,6 +104,27 @@ function set_config_variable() {
     load_config
 }
 
+function gatk_prompt() {
+        echo "
+ The recommended version of GATK for Cpipe is 3.5. However license
+ terms prevent Cpipe from including this version with Cpipe. Cpipe
+ includes GATK 2.3.9 which can be used instead. If you wish to use
+ a later version of GATK, please abort this script (Ctrl-c), download
+ that version after separately agreeing to the license terms, and
+ place the jar file in tools/gatk/<version>/GenomeAnalysisTK.jar. Once
+ you have done that, set the GATK variable in pipeline/config.groovy
+ appropriately and re-run this script.
+    "
+        prompt "Continue with GATK 2.3.9? (y/n)" "y"
+        if [ "$REPLY" == "y" ];
+        then
+            set_config_variable GATK "$TOOLS/gatk/2.3.9"
+            set_config_variable GATK_LEGACY "true"
+        else
+            msg "WARNING: your installation will not work unless you set GATK manually youself in pipeline/config.groovy"
+        fi
+}
+
 echo '
 ========================================
 
@@ -171,18 +192,15 @@ compile "$BEDTOOLS/bin/bedtools"
 
 msg "Check GATK is downloaded and available"
 [ -e $GATK/GenomeAnalysisTK.jar ] || {
-    echo "
- The recommended version of GATK for Cpipe is 3.6, but license 
- terms prevent Cpipe from including this version with Cpipe. 
- Please download GATK separately agreeing to the license terms, and 
- place the jar file in tools/gatk/<version>/GenomeAnalysisTK.jar. Once
- you have done that, set the GATK variable in pipeline/config.groovy 
- appropriately and re-run this script.
-    "
-    prompt "Continue without GATK? (y/n)" "y"
-    if [ "$REPLY" == "y" ];
-    then
-        msg "WARNING: your installation will not work unless you configure GATK manually youself in pipeline/config.groovy"
+    if [ -e $TOOLS/gatk/3.5 ];
+    then    
+       prompt "Found GATK 3.5. Continue with this version? (y/n)" "y"
+       if [ "$REPLY" == "y" ];
+       then
+           set_config_variable GATK '$TOOLS/gatk/3.5'
+       else
+           gatk_prompt
+       fi    
     else
         err "Please install GATK then re-run this script"
     fi


### PR DESCRIPTION
when there's a usable version of GATK already present in the tools
folder, this patch makes installer see it and set it in config.groovy -
prevents the awkward need to stop the installer and do manual 
steps in the middle
