### PR TITLE
put generation of corrected sample meta data file into pipeline

### DIFF
--- a/pipeline/pipeline.groovy
+++ b/pipeline/pipeline.groovy
@@ -42,13 +42,13 @@ requires EXOME_TARGET : """
     """
 
 /////////////////////////////////////////////////////////
-sample_metadata_file = correct_sample_metadata_file(args[0]) // fix syntax issues and update sample_metadata_file
+corrected_sample_metadata_file = correct_sample_metadata_file(args[0]) // fix syntax issues and update corrected_sample_metadata_file
 
 try {
-  sample_info = SampleInfo.parse_mg_sample_info(sample_metadata_file)
+  sample_info = SampleInfo.parse_mg_sample_info(corrected_sample_metadata_file)
 }
 catch (RuntimeException e) {
-  sample_info = SampleInfo.parse_sample_info(sample_metadata_file)
+  sample_info = SampleInfo.parse_sample_info(corrected_sample_metadata_file)
 }
 
 // We are specifying that each analysis takes place inside a fixed file structure

--- a/pipeline/pipeline_helpers.groovy
+++ b/pipeline/pipeline_helpers.groovy
@@ -24,13 +24,26 @@
 
 // remove spaces from gene lists and point to a new sample metadata file
 // note that this isn't run through bpipe
-correct_sample_metadata_file = {
+
+correct_sample_meta_data_command = { input, output ->
+   "python $SCRIPTS/correct_sample_metadata_file.py < $input > $output"  
+}
+
+correct_sample_metadata_file = { 
     def target = new File('results')
     if( !target.exists() ) {
         target.mkdirs()
     }
-    [ "sh", "-c", "python $SCRIPTS/correct_sample_metadata_file.py < $it > results/samples.corrected" ].execute().waitFor()
+    [ "sh", "-c", correct_sample_meta_data_command(it,'results/samples.corrected')].execute().waitFor()
     return "results/samples.corrected"
+}
+
+correct_sample_metadata_stage = {
+    output.dir='results'
+    filter('corrected') {
+        exec correct_sample_meta_data_command(input.txt, output.txt)
+    }
+    branch.sample_metadata_file = output.txt
 }
 
 /////////////////////////////////////////////////////////

--- a/pipeline/pipeline_stage_initialize.groovy
+++ b/pipeline/pipeline_stage_initialize.groovy
@@ -115,11 +115,11 @@ update_gene_lists = {
             exec """
                 mkdir -p "../design"
 
-                python $SCRIPTS/find_new_genes.py --reference "$BASE/designs/genelists/exons.bed" --exclude "$BASE/designs/genelists/incidentalome.genes.txt" --target ../design < $sample_metadata_file
+                python $SCRIPTS/find_new_genes.py --reference "$BASE/designs/genelists/exons.bed" --exclude "$BASE/designs/genelists/incidentalome.genes.txt" --target ../design < $input1
 
                 python $SCRIPTS/update_gene_lists.py --source ../design --target "$BASE/designs" --log "$BASE/designs/genelists/changes.genes.log"
 
-                touch update_gene_lists.log
+                touch $output1
             """
         }
     }
@@ -436,6 +436,7 @@ initialize_batch_run = segment {
     // ANALYSIS_PROFILES = sample_info*.value*.target as Set
     // Check the basic sample information first
     check_sample_info +  // check that fastq files are present
+    correct_sample_metadata_stage +
     check_tools +
     update_gene_lists + // build new gene lists by adding sample specific genes to cohort
 


### PR DESCRIPTION
this is needed because the current strategy updates the samples.corrected
file every run, which means any downstream stage consuming that file
wants to run again even after the pipeline completed. The
implementation is a bit clumsy, it creates two corrected samples.txt
files - one for the pre-pipeline steps to use, and then one for the
actual pipeline to use. Probably can fix this by putting the
correction steps into the SampleInfo class itself rather than
having a separate python script to do them.
