### PR TITLE
refactor vep calls out of scripts and back into main pipeline

### DIFF
--- a/pipeline/pipeline_stage_variant_analysis.groovy
+++ b/pipeline/pipeline_stage_variant_analysis.groovy
@@ -61,12 +61,67 @@ vcf_filter_child = {
 
 @filter("vep")
 vcf_annotate = {
-    doc "annotate variants"
+    doc "Annotate variants using VEP"
+    
+    // DBNSFP is disabled by default because it requires a very large download (300GB+) that many users may
+    // not want to do
+    var ENABLE_DBNSFP : false
+    
+    def DBNSFP_OPTS=""
+    if(ENABLE_DBNSFP) {
+        DBNSFP_OPTS=" --plugin dbNSFP,$DBNSFP/dbNSFP.gz,SIFT_pred,Polyphen2_HDIV_score,Polyphen2_HDIV_rankscore,Polyphen2_HDIV_pred,Polyphen2_HVAR_score,Polyphen2_HVAR_rankscore,Polyphen2_HVAR_pred,LRT_score,LRT_converted_rankscore,LRT_pred,MutationTaster_score,MutationTaster_converted_rankscore,MutationTaster_pred,MutationAssessor_score,MutationAssessor_rankscore,MutationAssessor_pred,FATHMM_score,FATHMM_rankscore,FATHMM_pred,MetaSVM_score,MetaSVM_rankscore,MetaSVM_pred,MetaLR_score,MetaLR_rankscore,MetaLR_pred,Reliability_index,VEST3_score,VEST3_rankscore,PROVEAN_score,PROVEAN_converted_rankscore,PROVEAN_pred,CADD_raw,CADD_raw_rankscore,CADD_phred,GERP++_NR,GERP++_RS,GERP++_RS_rankscore,phyloP46way_primate,phyloP46way_primate_rankscore,phyloP46way_placental,phyloP46way_placental_rankscore,phyloP100way_vertebrate,phyloP100way_vertebrate_rankscore,phastCons46way_primate,phastCons46way_primate_rankscore,phastCons46way_placental,phastCons46way_placental_rankscore,phastCons100way_vertebrate,phastCons100way_vertebrate_rankscore,SiPhy_29way_pi,SiPhy_29way_logOdds,SiPhy_29way_logOdds_rankscore,LRT_Omega,UniSNP_ids,1000Gp1_AC,1000Gp1_AF,1000Gp1_AFR_AC,1000Gp1_AFR_AF,1000Gp1_EUR_AC,1000Gp1_EUR_AF,1000Gp1_AMR_AC,1000Gp1_AMR_AF,1000Gp1_ASN_AC,1000Gp1_ASN_AF,ESP6500_AA_AF,ESP6500_EA_AF ARIC5606_AA_AC,ARIC5606_AA_AF,ARIC5606_EA_AC,ARIC5606_EA_AF,ExAC_AC,ExAC_AF,ExAC_Adj_AC,ExAC_Adj_AF,ExAC_AFR_AC,ExAC_AFR_AF,ExAC_AMR_AC,ExAC_AMR_AF,ExAC_EAS_AC,ExAC_EAS_AF,ExAC_FIN_AC,ExAC_FIN_AF,ExAC_NFE_AC,ExAC_NFE_AF,ExAC_SAS_AC,ExAC_SAS_AF,clinvar_rs,clinvar_clnsig,clinvar_trait,COSMIC_ID,COSMIC_CNT"
+    }
+    
     stage_status("vcf_annotate", "enter", "${sample} ${branch.analysis}");
     output.dir="variants"
+    
     // NB we write an empty output file for the case where vep doesn't write anything
+    //    /usr/bin/env bash $SCRIPTS/vcf_annotate.sh "$input.vcf" "$output.vcf" "$HTSLIB" "$VEP" "$TOOLS" "$CONDEL" "$DBNSFP"
     exec """
-        /usr/bin/env bash $SCRIPTS/vcf_annotate.sh "$input.vcf" "$output.vcf" "$HTSLIB" "$VEP" "$TOOLS" "$CONDEL" "$DBNSFP"
+        export PERL5LIB="$PERL5LIB:$TOOLS/perl5:$TOOLS/perl5/lib/perl5";
+        
+        echo "$VARIANTS variant(s) found in $input.vcf";
+
+        VARIANTS=`grep -c -v '^#' < $input.vcf`
+
+        if [ $VARIANTS -eq 0 ];
+        then
+            grep '^#' $input.vcf > $output.vcf;
+        else
+            PATH="$PATH:$HTSLIB"
+            perl $VEP/variant_effect_predictor.pl 
+                --allele_number
+                --assembly GRCh37 
+                --cache 
+                --canonical 
+                --check_alleles 
+                --check_existing 
+                --dir $VEP/../vep_cache 
+                --dir_plugins $TOOLS/vep_plugins 
+                --fasta $VEP/../vep_cache/homo_sapiens/83_GRCh37/Homo_sapiens.GRCh37.75.dna.primary_assembly.fa.gz 
+                --force_overwrite
+                --gmaf
+                --hgvs 
+                -i $input.vcf
+                --maf_1kg 
+                --maf_esp 
+                --maf_exac 
+                -o $output.vcf
+                --offline
+                --per_gene
+                --plugin Condel,$CONDEL/config,s ${DBNSFP_OPTS}
+                --plugin Grantham
+                --polyphen b
+                --protein
+                --pubmed
+                --refseq
+                --sift b
+                -species homo_sapiens
+                --symbol
+                --vcf
+                --vcf_info_field ANN
+                --verbose;
+        fi
     """
     stage_status("vcf_annotate", "exit", "${sample} ${branch.analysis}");
 }
@@ -78,8 +133,26 @@ vcf_post_annotation_filter = {
     output.dir="variants"
     // PERL5LIB="/vlsci/VR0320/shared/production/2.2.0/tools/vep/83" perl /vlsci/VR0320/shared/production/2.2.0/tools/vep/83/filter_vep.pl --input_file txxxx.genotype.raw.split.norm.ChildOnly.vep.83.vcf --format vcf --filter "Consequence not matches stream" --only_matched --filter "BIOTYPE match protein_coding" --filter "Feature" -o txxxx.genotype.raw.split.norm.ChildOnly.vep.83.FILTER.vcf
     // first copy input to output, otherwise filter_vep creates an empty file
+    // /usr/bin/env bash $SCRIPTS/vcf_post_annotation_filter.sh "$input.vcf" "$output.vcf" "$VEP" "$TOOLS"
     exec """
-        /usr/bin/env bash $SCRIPTS/vcf_post_annotation_filter.sh "$input.vcf" "$output.vcf" "$VEP" "$TOOLS"
+        VARIANTS=`grep -c -v '^#' < $input.vcf`
+
+        echo "$VARIANTS variant(s) found in $input.vcf"
+
+        if [ $VARIANTS -eq 0 ];
+        then
+          cp $input.vcf $output.vcf;
+        else
+          PERL5LIB="$TOOLS/perl5:$TOOLS/perl5/lib/perl5:$VEP" perl $VEP/filter_vep.pl 
+            --input_file $input.vcf
+            --filter "Consequence not matches stream" 
+            --filter "BIOTYPE match protein_coding"
+            --filter "Feature" 
+            --force_overwrite
+            --format vcf
+            -o $output.vcf
+            --only_matched ;
+        fi
     """
     stage_status("vcf_post_annotation_filter", "exit", "${sample} ${branch.analysis}");
 }


### PR DESCRIPTION
This is to improve traceability, but will require tests for
these scripts to call bpipe to run commands. That should now
be able to be accomplished using 'bpipe execute' with support
for --source in the 0.9.9.3 bpipe version.
