### PR TITLE
use msg not exec/echo for showing message

### DIFF
--- a/pipeline/pipeline_stage_initialize.groovy
+++ b/pipeline/pipeline_stage_initialize.groovy
@@ -212,8 +212,8 @@ set_target_info = {
 
     var HG19_CHROM_INFO : false
 
-    exec """
-        echo "set_target_info: combined target is $COMBINED_TARGET"
+    msg """
+        set_target_info: combined target is $COMBINED_TARGET
     """
 
     branch.splice_region_window=false


### PR DESCRIPTION
the reason to do this is that seeing an "exec" with no output, Bpipe will
run this command every time as a command, and "bpipe test" will stop here
as the first command to execute, even when the whole pipeline was already
executed
