### PR TITLE
fix 'bpipe test' always stops at first stage

### DIFF
--- a/pipeline/pipeline_helpers.groovy
+++ b/pipeline/pipeline_helpers.groovy
@@ -24,13 +24,22 @@
 
 // remove spaces from gene lists and point to a new sample metadata file
 // note that this isn't run through bpipe
-correct_sample_metadata_file = {
+correct_sample_metadata_file = { sample_meta_data_file ->
     def target = new File('results')
     if( !target.exists() ) {
         target.mkdirs()
     }
-    [ "sh", "-c", "python $SCRIPTS/correct_sample_metadata_file.py < $it > results/samples.corrected" ].execute().waitFor()
-    return "results/samples.corrected"
+    
+    def outputFile = "results/samples.corrected"
+    
+    if(file(outputFile).exists() && file(outputFile).lastModified() > file(sample_meta_data_file).lastModified()) {
+        println "Skip creating corrected meta data file (up-to-date)"
+    }
+    else {
+        println "Creating corrected meta data file"
+        println([ "sh", "-c", "python $SCRIPTS/correct_sample_metadata_file.py < $sample_meta_data_file > $outputFile" ].execute().text)
+    }
+    return outputFile
 }
 
 /////////////////////////////////////////////////////////


### PR DESCRIPTION
The way this stage currently executes it always writes the output file even if the file already existed. The problem with that is that it causes the following stages to see the file as newer and thus that they need to be re-executed, hence causing large parts of the pipeline to re-execute even if everything is up to date. This is most painful when testing as "bpipe test" always stops at the first stage instead of allowing the pipeline to continue.

This change puts a conditional around the creation of the file so that it is only created if it is out of date with respect to the input file.