### PR TITLE
Fix race condition that makes multi-process installation fail

### DIFF
--- a/dodo.py
+++ b/dodo.py
@@ -72,6 +72,7 @@ def task_tool_assets():
             'install_bcftools',
             'install_bedtools',
             'install_gatk',
+            'install_perl_libs',
             'install_vep',
             'install_fastqc',
             'install_groovy',

--- a/dodo.py
+++ b/dodo.py
@@ -17,6 +17,9 @@ from doit.tools import PythonInteractiveAction
 
 from cpipe import get_version
 from cpipe.scripts import create_bpipe_config
+from multiprocessing import Lock
+
+lock = Lock()
 
 DOIT_CONFIG = {
     'default_tasks': ['install'],
@@ -72,7 +75,6 @@ def task_tool_assets():
             'install_bcftools',
             'install_bedtools',
             'install_gatk',
-            'install_perl_libs',
             'install_vep',
             'install_fastqc',
             'install_groovy',

--- a/dodo.py
+++ b/dodo.py
@@ -17,9 +17,6 @@ from doit.tools import PythonInteractiveAction
 
 from cpipe import get_version
 from cpipe.scripts import create_bpipe_config
-from multiprocessing import Lock
-
-lock = Lock()
 
 DOIT_CONFIG = {
     'default_tasks': ['install'],

--- a/tasks/nectar/__init__.py
+++ b/tasks/nectar/__init__.py
@@ -1,1 +1,4 @@
+from multiprocessing import Lock
+
+lock = Lock()
 

--- a/tasks/nectar/nectar_util.py
+++ b/tasks/nectar/nectar_util.py
@@ -10,6 +10,7 @@ from urllib.parse import urlparse, urljoin
 from urllib.request import urlretrieve
 
 from tasks.common import unzip_todir, has_swift_auth, ROOT, MANUAL_INSTALL
+from . import lock
 
 current_dir = path.dirname(__file__)
 current_manifest = path.join(current_dir, 'current.manifest.json')

--- a/tasks/nectar/nectar_util.py
+++ b/tasks/nectar/nectar_util.py
@@ -11,15 +11,15 @@ from urllib.request import urlretrieve
 
 from tasks.common import unzip_todir, has_swift_auth, ROOT, MANUAL_INSTALL
 
-
 current_dir = path.dirname(__file__)
 current_manifest = path.join(current_dir, 'current.manifest.json')
 target_manifest = path.join(current_dir, 'target.manifest.json')
 
 def add_to_manifest(key):
     """Copy the JSON objects from the target JSON file to current JSON file"""
+    lock.acquire()
     with open(target_manifest, 'r') as target, \
-            open(current_manifest, 'r+') as current:
+         open(current_manifest, 'r+') as current:
         target_json = json.load(target)
         current_json = json.load(current)
         current_json[key] = target_json[key]
@@ -27,6 +27,7 @@ def add_to_manifest(key):
         current.truncate()
         json.dump(current_json, current, indent=4)
 
+    lock.release()
 
 def create_current_manifest():
     # Create the current manifest if it doesn't exist


### PR DESCRIPTION
It took quite a while to figure out this bug. When running `install.sh -n <greaterthanone>` caused race condition to update the `current.manifest.json` file. More details here: https://github.com/pydoit/doit/issues/230